### PR TITLE
Adding travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
+
+language: c
+
+os:
+  - linux
+
+env:
+   global:
+     - R_LIBS="http://cran.rstudio.com"
+     - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+     - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+     - BOOTSTRAP_LATEX=""
+     - NOT_CRAN="true"
+
+before_install:
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+
+after_script:
+  - "./travis-tool.sh dump_logs"
+
+install:
+  - ./travis-tool.sh install_deps
+
+script: ./travis-tool.sh run_tests
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ smwrData
 
 Data sets as data.frames and as text files from U.S. Geological Survey publications.
 
+Installation
+----------
+
+
+```R
+install.packages("smwrData", repos=c("http://owi.usgs.gov/R"))
+```
+
+
+
 Disclaimer
 ----------
 This software is in the public domain because it contains materials that originally came from the U.S. Geological Survey, an agency of the United States Department of Interior. For more information, see the official USGS copyright policy at [http://www.usgs.gov/visual-id/credit_usgs.html#copyright](http://www.usgs.gov/visual-id/credit_usgs.html#copyright)
@@ -11,19 +21,10 @@ Although this software program has been used by the U.S. Geological Survey (USGS
 
 This software is provided "AS IS."
 
-Installation
-----------
+ [
+   ![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)
+ ](http://creativecommons.org/publicdomain/zero/1.0/)
+ 
+Linix: [![travis](https://travis-ci.org/USGS-R/smwrData.svg?branch=master)](https://travis-ci.org/USGS-R/smwrData)
 
-**for windows**:
-```R
-install.packages("smwrData", 
-    repos=c("http://owi.usgs.gov/R"), 
-    dependencies=TRUE)
-```
 
-**for mac**:
-```R
-install.packages("smwrData", 
-    repos=c("http://owi.usgs.gov/R"), 
-    dependencies=TRUE, type = "both")
-```


### PR DESCRIPTION
This is an example of how to use travis for an external check on the packages. The packages with dependences not on CRAN can also be run with install_github, and GRAN could be used too by adjusting the - CRAN: http://cran.rstudio.com argument in the global env. I'll have to play around with that at some point to figure it out exactly. But first, let's start easy with the data package.
